### PR TITLE
Add Golden Path Strands framework skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+      - name: Run pre-commit
+        run: pre-commit run --files $(git ls-files '*.py')
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 [![AWS Strands](https://img.shields.io/badge/AWS-Strands-orange.svg)](https://github.com/strands-agents/sdk-python)
 [![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-Enabled-green.svg)](https://opentelemetry.io/)
+[![CI](https://github.com/JohnJBoren/golden-path-strands/actions/workflows/ci.yml/badge.svg)](https://github.com/JohnJBoren/golden-path-strands/actions/workflows/ci.yml)
 
 > **Transform expensive AI agent explorations into efficient, production-ready systems through systematic optimization**
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,3 @@
+model_provider: stub
+telemetry_endpoint: http://localhost:4318
+data_dir: data

--- a/examples/quick_start.py
+++ b/examples/quick_start.py
@@ -1,0 +1,14 @@
+"""Minimal usage example for the Golden Path Strands framework."""
+import asyncio
+
+from golden_path_strands import GoldenPathStrands
+
+
+async def main() -> None:
+    gps = GoldenPathStrands()
+    dataset_path = await gps.run_complete_pipeline(["example task"])
+    print(f"Dataset written to {dataset_path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "golden-path-strands"
+version = "0.1.0"
+description = "Golden Path Strands framework"
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [{name = "John Boren"}]
+dependencies = [
+    "pyyaml",
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "black",
+    "flake8",
+    "isort",
+    "pre-commit",
+]
+
+[tool.setuptools.package-dir]
+"" = "src"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+pythonpath = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyyaml
+opentelemetry-sdk
+opentelemetry-exporter-otlp

--- a/src/golden_path_strands/__init__.py
+++ b/src/golden_path_strands/__init__.py
@@ -1,0 +1,4 @@
+"""Top-level package for Golden Path Strands framework."""
+from .core import GoldenPathStrands
+
+__all__ = ["GoldenPathStrands"]

--- a/src/golden_path_strands/config.py
+++ b/src/golden_path_strands/config.py
@@ -1,0 +1,43 @@
+"""Configuration management utilities."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+try:  # pragma: no cover - optional dependency
+    import yaml
+except Exception:  # pragma: no cover
+    yaml = None
+
+
+@dataclass
+class Settings:
+    model_provider: str = "stub"
+    telemetry_endpoint: str | None = None
+    data_dir: str = "data"
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+def load_config(path: str = "config.yaml") -> Settings:
+    """Load configuration from YAML file and environment variables.
+
+    YAML parsing is optional; if :mod:`pyyaml` is unavailable the file is assumed to
+    contain JSON and parsed accordingly. Missing files result in default settings.
+    """
+    config: Dict[str, Any] = {}
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf8") as fh:
+            text = fh.read()
+            if yaml is not None:
+                config = yaml.safe_load(text) or {}
+            else:
+                config = json.loads(text or "{}")
+    prefix = "GPS_"
+    env_overrides = {k[len(prefix):].lower(): v for k, v in os.environ.items() if k.startswith(prefix)}
+    config.update(env_overrides)
+    extra = {k: v for k, v in config.items() if k not in Settings.__dataclass_fields__}
+    settings_kwargs = {k: config.get(k) for k in Settings.__dataclass_fields__ if k in config}
+    settings = Settings(**{**settings_kwargs, "extra": extra})
+    return settings

--- a/src/golden_path_strands/core.py
+++ b/src/golden_path_strands/core.py
@@ -1,0 +1,60 @@
+"""Core orchestrator for the Golden Path Strands framework."""
+from __future__ import annotations
+
+from typing import Dict, List, Any
+
+from .logging import ExplorationLogger
+from .evaluation import LLMJudgeEvaluator
+from .dataset import DatasetCreator
+from .config import load_config
+
+
+class GoldenPathStrands:
+    """High level orchestrator coordinating exploration, evaluation and dataset creation."""
+
+    def __init__(self, config: Dict | None = None) -> None:
+        """Create a new orchestrator instance.
+
+        Parameters
+        ----------
+        config:
+            Optional configuration dictionary. If ``None`` a configuration file and
+            environment variables will be consulted.
+        """
+        self.config = config or load_config()
+        self.logger = ExplorationLogger()
+        self.evaluator = LLMJudgeEvaluator()
+        self.dataset_creator = DatasetCreator()
+
+    async def discover_golden_paths(self, tasks: List[str], iterations: int = 3) -> List[Dict[str, Any]]:
+        """Stub exploration routine.
+
+        The current implementation simply logs the provided tasks and returns a list of
+        mock path dictionaries. In a full system this would coordinate multiple agents
+        exploring the search space.
+        """
+        paths: List[Dict[str, Any]] = []
+        for task in tasks:
+            for i in range(iterations):
+                decision = {"task": task, "iteration": i, "result": f"result-{i}"}
+                self.logger.log_decision_point(decision, {"task": task})
+                # pretend each iteration produces a path
+                evaluation = await self.evaluator.evaluate_response(task, decision["result"], [])
+                score = self.evaluator.get_consensus_score(evaluation)
+                if score >= 0:
+                    self.logger.mark_path_successful(score, decision)
+                    paths.append({"task": task, "score": score, "decision": decision})
+        return paths
+
+    async def create_training_dataset(self, paths: List[Dict[str, Any]]) -> str:
+        """Persist successful paths as a JSONL dataset.
+
+        Returns the path to the created dataset file.
+        """
+        return self.dataset_creator.write_paths(paths)
+
+    async def run_complete_pipeline(self, tasks: List[str]) -> str:
+        """Execute exploration, evaluation and dataset creation end-to-end."""
+        paths = await self.discover_golden_paths(tasks)
+        dataset_path = await self.create_training_dataset(paths)
+        return dataset_path

--- a/src/golden_path_strands/dataset.py
+++ b/src/golden_path_strands/dataset.py
@@ -1,0 +1,20 @@
+"""Utilities for constructing training datasets from successful paths."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Any
+
+
+class DatasetCreator:
+    """Write successful exploration paths to a JSONL dataset."""
+
+    def __init__(self, output_path: str | Path | None = None) -> None:
+        self.output_path = Path(output_path or "dataset.jsonl")
+
+    def write_paths(self, paths: List[Dict[str, Any]]) -> str:
+        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.output_path.open("w", encoding="utf8") as fh:
+            for path in paths:
+                fh.write(json.dumps(path) + "\n")
+        return str(self.output_path)

--- a/src/golden_path_strands/evaluation.py
+++ b/src/golden_path_strands/evaluation.py
@@ -1,0 +1,25 @@
+"""Evaluation utilities using LLM-as-judge style scoring."""
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, List
+
+
+class LLMJudgeEvaluator:
+    """Simple evaluator that fakes LLM-judge responses.
+
+    Real implementations would call out to multiple model providers and aggregate
+    their scores. The stub provided here simply returns a deterministic score based
+    on the response length so tests can exercise the pipeline without external
+    dependencies.
+    """
+
+    async def evaluate_response(self, query: str, response: str, tools: List[str]) -> List[Dict]:
+        await asyncio.sleep(0)  # allow context switch
+        score = len(response) % 5 / 5  # deterministic pseudo-score
+        return [{"model": "stub", "score": score}]
+
+    def get_consensus_score(self, evaluations: List[Dict]) -> float:
+        if not evaluations:
+            return 0.0
+        return sum(e["score"] for e in evaluations) / len(evaluations)

--- a/src/golden_path_strands/logging.py
+++ b/src/golden_path_strands/logging.py
@@ -1,0 +1,25 @@
+"""Logging utilities for exploration runs."""
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Any
+
+
+class ExplorationLogger:
+    """Collects structured logs for decision points and successful paths."""
+
+    def __init__(self) -> None:
+        self._logs: List[str] = []
+        self._successful: List[Dict[str, Any]] = []
+
+    def log_decision_point(self, agent_result: Any, context: Dict) -> None:
+        entry = {"event": "decision_point", "result": agent_result, "context": context}
+        self._logs.append(json.dumps(entry))
+
+    def mark_path_successful(self, score: float, metadata: Dict) -> None:
+        entry = {"score": score, "metadata": metadata}
+        self._logs.append(json.dumps({"event": "successful_path", **entry}))
+        self._successful.append(entry)
+
+    def get_successful_paths(self) -> List[Dict[str, Any]]:
+        return list(self._successful)

--- a/src/golden_path_strands/monitoring.py
+++ b/src/golden_path_strands/monitoring.py
@@ -1,0 +1,32 @@
+"""Monitoring helpers integrating with OpenTelemetry."""
+from __future__ import annotations
+
+from opentelemetry import metrics
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+
+
+def setup_telemetry(service_name: str, endpoint: str) -> None:
+    """Configure OpenTelemetry metrics exporter."""
+    resource = Resource.create({"service.name": service_name})
+    exporter = OTLPMetricExporter(endpoint=endpoint)
+    reader = PeriodicExportingMetricReader(exporter)
+    provider = MeterProvider(resource=resource, metric_readers=[reader])
+    metrics.set_meter_provider(provider)
+
+
+class MetricsCollector:
+    """Simple wrapper around OpenTelemetry metrics."""
+
+    def __init__(self) -> None:
+        self._meter = metrics.get_meter(__name__)
+        self._exploration_counter = self._meter.create_counter("exploration_count")
+        self._evaluation_latency = self._meter.create_histogram("evaluation_latency_ms")
+
+    def record_exploration(self) -> None:
+        self._exploration_counter.add(1)
+
+    def record_evaluation_latency(self, latency_ms: float) -> None:
+        self._evaluation_latency.record(latency_ms)

--- a/src/golden_path_strands/training.py
+++ b/src/golden_path_strands/training.py
@@ -1,0 +1,31 @@
+"""Simple training workflow stub."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def train(dataset_path: str) -> int:
+    """Pretend to train a model using the given dataset.
+
+    The function counts the number of examples in the dataset and returns that count.
+    """
+    path = Path(dataset_path)
+    if not path.exists():
+        raise FileNotFoundError(dataset_path)
+    count = sum(1 for _ in path.open())
+    # In real life, launch a fine-tuning job here
+    return count
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Train model on golden paths dataset")
+    parser.add_argument("--dataset", default="dataset.jsonl", help="Path to dataset JSONL")
+    args = parser.parse_args()
+    count = train(args.dataset)
+    print(f"Training invoked on {args.dataset} with {count} examples")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,10 @@
+import asyncio
+from pathlib import Path
+
+from golden_path_strands import GoldenPathStrands
+
+
+def test_complete_pipeline(tmp_path: Path) -> None:
+    gps = GoldenPathStrands(config={"data_dir": str(tmp_path)})
+    dataset_path = asyncio.run(gps.run_complete_pipeline(["test task"]))
+    assert Path(dataset_path).exists()

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,10 @@
+import asyncio
+
+from golden_path_strands.evaluation import LLMJudgeEvaluator
+
+
+def test_consensus_score() -> None:
+    ev = LLMJudgeEvaluator()
+    evaluations = asyncio.run(ev.evaluate_response("q", "resp", []))
+    score = ev.get_consensus_score(evaluations)
+    assert 0.0 <= score <= 1.0

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,9 @@
+from golden_path_strands.logging import ExplorationLogger
+
+
+def test_logger_tracks_success() -> None:
+    logger = ExplorationLogger()
+    logger.log_decision_point({"result": "foo"}, {"task": "t"})
+    logger.mark_path_successful(0.5, {"meta": 1})
+    paths = logger.get_successful_paths()
+    assert paths and paths[0]["score"] == 0.5


### PR DESCRIPTION
## Summary
- scaffold Python package with GoldenPathStrands orchestrator, logging, evaluation, dataset and training stubs
- add configuration loader, monitoring hooks and usage example
- set up tests, pre-commit config and CI workflow

## Testing
- `pytest -q`
- `pre-commit run --files $(git ls-files '*.py')` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b5036b8b5883268462a12a4076139d